### PR TITLE
Remove possibility of format exception when R_HOME is resolved as null

### DIFF
--- a/ReportInfo/Program.cs
+++ b/ReportInfo/Program.cs
@@ -7,8 +7,8 @@ namespace ReportInfo
     {
         static void Main(string[] args)
         {
-            string rHome = null;
-            string rPath = null;
+            string rHome = string.Empty;
+            string rPath = string.Empty;
             if (args.Length > 0)
                 rPath = args[0];
             if (args.Length > 1)


### PR DESCRIPTION
A first chance exception of type 'System.FormatException' occurred in mscorlib.dll
Additional information: Input string was not in a correct format.
